### PR TITLE
Don't include jquery libs when fastbooting

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,9 @@ module.exports = {
 
     this.app = app;
 
-    app.import(app.bowerDirectory + '/jquery.payment/lib/jquery.payment.min.js');
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      app.import(app.bowerDirectory + '/jquery.payment/lib/jquery.payment.min.js');
+    }
 
     return app;
   }


### PR DESCRIPTION
jQuery isn't present when using Fastboot, so it's recommended to check before importing libraries that need DOM access